### PR TITLE
Add a lua interface for the C API snappy_validate_compressed_buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Here is a sample usage in shell:
         Lua 5.1.4 Copyright (C) 1994-2008 Lua.org, PUC-Rio
         > require "snappy"
         > compressed = snappy.compress("hello world!")
+        > indicator = snappy.validate_compressed_buffer(compressed)
+        > print(indicator)
+        true
         > uncompressed = snappy.uncompress(compressed) -- snappy.decompress(compressed) also works.
         > print(uncompressed)
         hello world!

--- a/lua-snappy.cc
+++ b/lua-snappy.cc
@@ -64,11 +64,25 @@ static int lsnappy_uncompress(lua_State *L)
     return luaL_error(L, "snappy: not enough memory.");
 }
 
+static int lsnappy_validate_compressed_buffer(lua_State *L) 
+{
+    size_t src_len = 0;
+    size_t dst_max_size = 0;
+    const char* src = luaL_checklstring(L, 1, &src_len);
+    if(snappy_validate_compressed_buffer(src, src_len) == SNAPPY_OK) {
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+    lua_pushboolean(L, 0);
+    return 1;
+}
+
 static const luaL_Reg snappy[] =
 {
     {"compress", lsnappy_compress},
     {"uncompress", lsnappy_uncompress},
     {"decompress", lsnappy_uncompress},
+    {"validate_compressed_buffer", lsnappy_validate_compressed_buffer},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
The C API snappy_validate_compressed_buffer (snappy/snappy-c.h, line 131)
`snappy_status snappy_validate_compressed_buffer(const char* compressed, size_t compressed_length);`
is used for checking if the contents of "compressed[]" can be uncompressed successfully. 
This API might been used before uncompress the buffered bytes . 
